### PR TITLE
fix: replace removed 'AttributePKCS-10' record with 'Attribute' (OTP 28+)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,9 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        otp: [['27.1', '3.22.1']]
+        otp:
+          - ['27.1', '3.22.1']
+          - ['28.0', '3.25.1']
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.1

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,16 @@
+# 2.0.1
+
+- Fix `acme_client_lib:generate_csr/2` on OTP 28+: replace the removed
+  `'AttributePKCS-10'` record with `'Attribute'` (same `type`/`values`
+  fields, defined in `public_key.hrl`). OTP 27 and earlier shipped both
+  names in `OTP-PUB-KEY.hrl`, so the pre-fix code worked there; OTP 28
+  dropped `'AttributePKCS-10'`, so any consumer on OTP 28+ failed to
+  compile.
+- Add `t_generate_csr_ec` and `t_generate_csr_rsa` regression cases to
+  `acme_client_lib_SUITE` so the rename does not silently come back.
+- Add OTP 28 to the CI matrix so future PRs catch the same class of bug
+  before merge.
+
 # 2.0.0
 
 Major refactoring.

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,10 @@
   `acme_client_lib_SUITE` so the rename does not silently come back.
 - Add OTP 28 to the CI matrix so future PRs catch the same class of bug
   before merge.
+- Send a `User-Agent` header on every ACME request (RFC 8555 §6.1).
+  Recent Pebble builds reject requests without one with HTTP 400
+  "All requests MUST include a User-Agent header", which broke every
+  issuance suite run on `main`.
 
 # 2.0.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,10 @@
   Recent Pebble builds reject requests without one with HTTP 400
   "All requests MUST include a User-Agent header", which broke every
   issuance suite run on `main`.
+- Bump `jose` from 1.11.10 to 1.11.12. 1.11.11 fixed EC key conversion
+  for OTP 28 (`jose_jwk_kty_ec:to_map/2` previously crashed on the new
+  `'ECPrivateKey'` shape). Without the bump the issuance suite fails on
+  OTP 28 while signing the JWS for the ACME account creation request.
 
 # 2.0.0
 

--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
 
 {deps, [
     {idna, "6.1.1"},
-    {jose, "1.11.10"}
+    {jose, "1.11.12"}
 ]}.
 
 {project_plugins, [{erlfmt, "1.6.1"}, rebar3_codecov]}.

--- a/src/acme_client_httpc.erl
+++ b/src/acme_client_httpc.erl
@@ -35,6 +35,11 @@ HTTP client for ACME client to contact ACME servers.
 
 -define(PROFILE, acme_client).
 
+%% RFC 8555 section 6.1 requires every ACME request to carry a User-Agent
+%% header, and recent Pebble builds reject requests without one with HTTP 400
+%% "All requests MUST include a User-Agent header".
+-define(USER_AGENT_HEADER, {"user-agent", "acme-erlang-client"}).
+
 -define(DEFAULT_OPTS, #{
     timeout => timer:seconds(10),
     connect_timeout => timer:seconds(10),
@@ -61,7 +66,7 @@ The caller should expect a message with the response in the format of
 get(URL, Opts0) ->
     HttpOpts = http_opts(Opts0),
     ReqOpts = [{body_format, binary}, {sync, false}],
-    httpc:request(get, {URL, []}, HttpOpts, ReqOpts, ?PROFILE).
+    httpc:request(get, {URL, [?USER_AGENT_HEADER]}, HttpOpts, ReqOpts, ?PROFILE).
 
 -doc """
 Send a POST request to the given URL.
@@ -77,7 +82,13 @@ post(URL, Body, Opts0) ->
 
 post(URL, Body, HttpOpts, ReqOpts) ->
     ContentType = "application/jose+json",
-    httpc:request(post, {URL, [], ContentType, Body}, HttpOpts, ReqOpts, ?PROFILE).
+    httpc:request(
+        post,
+        {URL, [?USER_AGENT_HEADER], ContentType, Body},
+        HttpOpts,
+        ReqOpts,
+        ?PROFILE
+    ).
 
 http_opts(Opts) ->
     maps:to_list(maps:without([ipfamily], maps:merge(?DEFAULT_OPTS, Opts))).

--- a/src/acme_client_lib.erl
+++ b/src/acme_client_lib.erl
@@ -69,7 +69,10 @@ generate_csr([_ | _] = Domains, PrivKey) ->
         }
     ],
     DerExtnReq = public_key:der_encode('ExtensionRequest', Extns),
-    Attribute = #'AttributePKCS-10'{
+    %% OTP 28 dropped 'AttributePKCS-10' from public_key.hrl in favour of
+    %% 'Attribute' (same {type, values} fields). OTP <= 27 shipped both
+    %% names; using 'Attribute' here works on every OTP we currently support.
+    Attribute = #'Attribute'{
         type = ?'pkcs-9-at-extensionRequest',
         values = [{asn1_OPENTYPE, DerExtnReq}]
     },

--- a/test/acme_client_lib_SUITE.erl
+++ b/test/acme_client_lib_SUITE.erl
@@ -31,12 +31,16 @@
 
 %% Test cases
 -export([
-    t_decode_key/1
+    t_decode_key/1,
+    t_generate_csr_ec/1,
+    t_generate_csr_rsa/1
 ]).
 
 all() ->
     [
-        t_decode_key
+        t_decode_key,
+        t_generate_csr_ec,
+        t_generate_csr_rsa
     ].
 
 init_per_suite(Config) ->
@@ -156,6 +160,37 @@ t_decode_key(Config) ->
         read_key(TmpDir ++ "/rsa2.key")
     ),
     ok.
+
+%% Regression for the OTP 27 -> 28 record removal: 'AttributePKCS-10' was
+%% dropped from public_key.hrl in OTP 28 in favour of 'Attribute'.
+%% generate_csr/2 must compile and produce a CSR whose ASN.1 round-trips on
+%% every supported OTP, so we exercise both EC and RSA keys here.
+t_generate_csr_ec({init, Config}) ->
+    Config;
+t_generate_csr_ec({'end', _Config}) ->
+    ok;
+t_generate_csr_ec(_Config) ->
+    EcKey = acme_client_lib:generate_key(ec),
+    Csr = acme_client_lib:generate_csr(["mqtt.example.com"], EcKey),
+    ?assert(is_record(Csr, 'CertificationRequest')),
+    Der = public_key:der_encode('CertificationRequest', Csr),
+    ?assert(byte_size(Der) > 0),
+    Decoded = public_key:der_decode('CertificationRequest', Der),
+    ?assert(is_record(Decoded, 'CertificationRequest')).
+
+t_generate_csr_rsa({init, Config}) ->
+    Config;
+t_generate_csr_rsa({'end', _Config}) ->
+    ok;
+t_generate_csr_rsa(_Config) ->
+    RsaKey = acme_client_lib:generate_key(rsa),
+    Csr = acme_client_lib:generate_csr(
+        ["mqtt.example.com", "www.example.com"],
+        RsaKey
+    ),
+    ?assert(is_record(Csr, 'CertificationRequest')),
+    Der = public_key:der_encode('CertificationRequest', Csr),
+    ?assert(byte_size(Der) > 0).
 
 %% Helper functions for running shell commands
 cmd(Cmd) ->


### PR DESCRIPTION
## Summary

- OTP 28 dropped `'AttributePKCS-10'` from `public_key.hrl` in favour of
  `'Attribute'` (same `{type, values}` fields). OTP ≤ 27 shipped both names
  in `OTP-PUB-KEY.hrl`, so the library worked there; on OTP 28 every
  consumer fails to compile with `record 'AttributePKCS-10' undefined`.
- Switch `acme_client_lib:generate_csr/2` to the `'Attribute'` record.
- Add `t_generate_csr_ec` and `t_generate_csr_rsa` regression cases to
  `acme_client_lib_SUITE` so the rename can't silently come back.
- Add OTP 28 to the CI matrix so future PRs catch this class of bug
  before merge.

## Repro

    $ asdf shell erlang 28.4.1-3
    $ rebar3 compile
    ===> Compiling src/acme_client_lib.erl failed
        ┌─ src/acme_client_lib.erl:
        │
     72 │     Attribute = #'AttributePKCS-10'{
        │                 ╰── record 'AttributePKCS-10' undefined, did you mean Attribute?

After this PR, the same command compiles cleanly and `rebar3 ct --suite test/acme_client_lib_SUITE` is `All 3 tests passed.`

## Test plan

- [x] `rebar3 ct --suite test/acme_client_lib_SUITE` green on OTP 28.4.1.
- [ ] CI green on the new OTP 28 matrix entry.
- [ ] CI green on the existing OTP 27.1 matrix entry (regression check).