### PR TITLE
fix: require contact entries to be binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Request = #{
     %% Domains to get certificate for
     %% Note: Not all ACME servers support wildcard certificates
     domains => [<<"example.com">>, <<"*.example.com">>],
-    %% Optional contact information
-    contact => ["mailto:admin@example.com"],
+    %% Optional contact information (binary or string)
+    contact => [<<"mailto:admin@example.com">>],
     %% Certificate key type (ec | rsa)
     cert_type => ec,
     %% Challenge type: "http-01" or "dns-01"

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,14 @@
+# 2.0.2
+
+- Require `contact` entries to be binaries. The README and typespec
+  previously advertised `[string()]`, but Erlang's stdlib `json` module
+  encodes a string (list of integers) as a JSON array of integers, so a
+  request with `contact => ["mailto:admin@example.com"]` was rejected
+  by ACME servers with `urn:ietf:params:acme:error:malformed` ("Error
+  unmarshaling JSON"). `make_data/3` now validates the input and
+  rejects non-binary entries with `{bad_contact, _}`. The typespec is
+  tightened to `[binary()]` and the README example uses a binary.
+
 # 2.0.1
 
 - Fix `acme_client_lib:generate_csr/2` on OTP 28+: replace the removed

--- a/src/acme_client_issuance.erl
+++ b/src/acme_client_issuance.erl
@@ -96,7 +96,7 @@ The client is implemented as a state machine with the following states:
 -type request() :: #{
     dir_url := dir_url(),
     domains := [domain()],
-    contact => [string()],
+    contact => [binary()],
     cert_type => cert_type(),
     ca_certs => [cert()],
     challenge_type => binary(),
@@ -271,7 +271,7 @@ make_data(DirURL, Domains, Request) ->
             caller_pid => self(),
             dir_url => URL,
             domains => IdnaDomains,
-            contact => maps:get(contact, Request, []),
+            contact => check_contact(maps:get(contact, Request, [])),
             cert_type => maps:get(cert_type, Request, ec),
             ca_certs => ensure_ca_certs(maps:get(ca_certs, Request, [])),
             challenge_type => maps:get(challenge_type, Request, <<"http-01">>),
@@ -802,6 +802,22 @@ check_domains([]) ->
     erlang:throw(empty_domains);
 check_domains(Domains) ->
     lists:map(fun(D) -> bin(idna:to_ascii(D)) end, Domains).
+
+%% Each contact entry must be a binary so that JSON encoding produces a
+%% JSON string. Erlang strings (lists of integers) would be encoded as
+%% integer arrays by `json:encode/1', which the ACME server rejects with
+%% `urn:ietf:params:acme:error:malformed'.
+check_contact(Contacts) when is_list(Contacts) ->
+    lists:foreach(
+        fun
+            (C) when is_binary(C) -> ok;
+            (C) -> erlang:throw({bad_contact, C})
+        end,
+        Contacts
+    ),
+    Contacts;
+check_contact(Other) ->
+    erlang:throw({bad_contact, Other}).
 
 set_request_id(RequestId, Data) ->
     Data#{request_id => RequestId}.

--- a/test/acme_client_issuance_SUITE.erl
+++ b/test/acme_client_issuance_SUITE.erl
@@ -130,6 +130,28 @@ t_invalid_args(_Config) ->
             }
         )
     ),
+    ?assertMatch(
+        {error, {bad_contact, 42}},
+        run(
+            #{
+                dir_url => "https://localhost:14000/dir",
+                domains => ["local.host"],
+                contact => [42]
+            }
+        )
+    ),
+    %% Erlang strings (lists of integers) are not accepted: callers must
+    %% pass binaries so JSON encoding produces a JSON string.
+    ?assertMatch(
+        {error, {bad_contact, "mailto:admin@local.net"}},
+        run(
+            #{
+                dir_url => "https://localhost:14000/dir",
+                domains => ["local.host"],
+                contact => ["mailto:admin@local.net"]
+            }
+        )
+    ),
     ok.
 
 t_one_domain({init, Config}) ->
@@ -137,10 +159,13 @@ t_one_domain({init, Config}) ->
 t_one_domain({'end', _Config}) ->
     ok;
 t_one_domain(_Config) ->
+    %% Exercise the binary-contact path so the ACME server receives valid
+    %% JSON strings in the newAccount request.
     R = run(
         #{
             dir_url => "https://localhost:14000/dir",
             domains => ["a.local.net"],
+            contact => [<<"mailto:admin@local.net">>],
             challenge_fn => fun challenge_fn/1,
             poll_interval => 100
         }


### PR DESCRIPTION
## Summary

A request that follows the README example with `contact => ["mailto:admin@example.com"]` (the documented `[string()]` form) is rejected by every real ACME CA at the `newAccount` step:

```
{error, #{cause => bad_response,
          response => #{<<"detail">> => <<"Error unmarshaling JSON">>,
                        <<"status">> => 400,
                        <<"type">> => <<"urn:ietf:params:acme:error:malformed">>}}}
```

Cause: `acme_client_issuance:json_encode/1` calls Erlang's stdlib `json:encode/1`, which serializes an Erlang string (list of integers) as a JSON array of integers — e.g. `"contact":[[109,97,105,108,116,111,...]]` — not a JSON string. The CA's JWS parser rejects the whole envelope as malformed.

The Pebble-backed CT suite never exercised this path because every existing test passes `contact => []`.

## Fix

`make_data/3` now runs `check_contact/1`, which requires every entry to be a `binary()` and rejects anything else with `{bad_contact, _}`. The request typespec is tightened to `[binary()]` and the README example uses a binary.

Strings are deliberately rejected rather than silently coerced — the contract is now unambiguous and matches what the wire format actually requires.

## Test plan

- [x] `make_data/3` returns `{error, {bad_contact, 42}}` on `[42]`
- [x] `make_data/3` returns `{error, {bad_contact, "..."}}` on a string entry
- [x] `make_data/3` returns `{error, {bad_contact, not_a_list}}` on a non-list
- [x] `[<<"mailto:...">>]` passes coercion (verified manually; CT covers the happy path against Pebble)
- [x] Verified end-to-end against Let's Encrypt staging — issuance succeeds with `contact => [<<"mailto:zmstone@gmail.com">>]`
- [x] `rebar3 compile` clean
- [x] `rebar3 dialyzer` clean
- [ ] CT suite passes (needs Pebble + the new `t_invalid_args` cases + the updated `t_one_domain` binary contact)