### PR TITLE
fix: return {stop, normal, Data} from s11_certificate success path

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,15 @@
+# 2.0.3
+
+- Fix `bad_return_from_state_function, ok` crash on the s11_certificate
+  success path. After `reply_caller/2` (which returns `ok`), the case
+  clause in `acme_client_issuance:s11_certificate(internal, {validate_ders, _}, _)`
+  was evaluating to `ok`, but gen_statem state callbacks must return a
+  state-transition tuple. The caller already had its `{ok, Result}` by
+  the time the state machine died, so the existing CT cases passed —
+  the only visible symptom was a crash report in the log right after
+  every successful issuance. The terminal-success clause now returns
+  `{stop, normal, Data}`, matching the abort path.
+
 # 2.0.2
 
 - Require `contact` entries to be binaries. The README and typespec

--- a/src/acme_client_issuance.erl
+++ b/src/acme_client_issuance.erl
@@ -730,7 +730,11 @@ s11_certificate(internal, {validate_ders, DERs}, Data) ->
                 cert_key => KeyFn(),
                 cert_chain => Chain
             },
-            ok = reply_caller(Data, {ok, Result});
+            ok = reply_caller(Data, {ok, Result}),
+            %% gen_statem state callbacks must return a state-transition
+            %% tuple. The terminal success path replies to the caller and
+            %% then stops the state machine.
+            {stop, normal, Data};
         {error, #{cause := _} = Reason} ->
             ?NEXT_ABORT(Data, Reason)
     catch


### PR DESCRIPTION
## Summary

Successful issuances log a crash report:

```
State machine <0.x.0> terminating. Reason: {bad_return_from_state_function,ok}.
Last event: {internal,{validate_ders,#Fun<...>}}.
State: {s11_certificate, ...}
```

`acme_client_issuance:s11_certificate(internal, {validate_ders, _}, _)` ends its success branch with

```erlang
{ok, Chain} ->
    Result = #{...},
    ok = reply_caller(Data, {ok, Result});
```

`reply_caller/2` returns `ok`, the case clause evaluates to `ok`, and gen_statem rejects the bare term — state callbacks must return a state-transition tuple.

The bug went unnoticed in CT because `do_run/2`'s `receive` matches the `{Ref, Result}` message sent by `reply_caller` first and returns `{ok, _}` to the test before the state machine dies — only the crash log is visible. Found in production while running the EMQX ACME plugin against Let's Encrypt staging.

## Fix

Return `{stop, normal, Data}` after replying, matching the abort path that's already in `handle_event/3`.

## Test plan

- [x] `rebar3 compile` clean
- [ ] Existing CT suite still green (gated on Pebble docker availability — runs in CI)
- [ ] Manual: a successful issuance no longer leaves a crash report in the log