### PR TITLE
fix: abort on non-badNonce HTTP_RETRY events instead of dropping them

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,16 @@
   the only visible symptom was a crash report in the log right after
   every successful issuance. The terminal-success clause now returns
   `{stop, normal, Data}`, matching the abort path.
+- Abort on non-`badNonce` `?HTTP_RETRY` events instead of dropping them.
+  Previously only `?HTTP_RETRY("badNonce")` was matched in
+  `handle_event/4`; any other retry signal — most commonly
+  `?HTTP_RETRY({unknown_response, Code, Slogan})` from a 4xx/5xx the
+  client doesn't have a recovery path for — fell through to the
+  catch-all `unknown_event_ignored` clause, leaving the state machine
+  stalled until `do_run/2`'s timeout fired. The new clause replies to
+  the caller with `{error, #{cause => http_retry_unrecoverable, reason
+  => Reason}}` and stops cleanly. Adds CT coverage in
+  `t_unrecoverable_http_retry_aborts`.
 
 # 2.0.2
 

--- a/rebar.config
+++ b/rebar.config
@@ -13,3 +13,9 @@
 
 {project_plugins, [{erlfmt, "1.6.1"}, rebar3_codecov]}.
 {xref_checks, [undefined_function_calls, deprecated_function_calls]}.
+
+{profiles, [
+    {test, [
+        {deps, [{meck, "1.0.0"}]}
+    ]}
+]}.

--- a/src/acme_client_issuance.erl
+++ b/src/acme_client_issuance.erl
@@ -766,6 +766,15 @@ handle_event(StateName, internal, ?HTTP_RETRY("badNonce"), Data) ->
     Delay = maps:get(poll_interval, Data),
     DelayAction = {timeout, Delay, {start, Delay}},
     {next_state, s2_nonce, Data, DelayAction};
+handle_event(StateName, internal, ?HTTP_RETRY(Reason), Data) ->
+    %% No bounded retry strategy is implemented for non-badNonce HTTP errors,
+    %% so any other ?HTTP_RETRY signal must abort with the original reason.
+    %% Falling through to the catch-all silently drops the event and stalls
+    %% the state machine until the caller's timeout fires.
+    Msg = "aborting_on_http_retry_at_state_" ++ atom_to_list(StateName),
+    ?LOG(warning, Msg, #{reason => Reason}),
+    ok = reply_caller(Data, {error, #{cause => http_retry_unrecoverable, reason => Reason}}),
+    {stop, normal, Data};
 handle_event(StateName, internal, ?ABORT(Reason), Data) ->
     ok = reply_caller(Data, {error, Reason}),
     Msg = "aborting_at_state_" ++ atom_to_list(StateName),

--- a/test/acme_client_issuance_SUITE.erl
+++ b/test/acme_client_issuance_SUITE.erl
@@ -477,3 +477,54 @@ t_dns01_one_domain(_Config) ->
 
 cmd(Cmd) ->
     acme_client_test_lib:cmd(Cmd).
+
+%% A non-badNonce HTTP retry signal (e.g. an unexpected 4xx from the CA)
+%% used to fall through `handle_event/4`'s catch-all and stall the state
+%% machine until `do_run/2`'s timeout fired. The new clause aborts with a
+%% structured `http_retry_unrecoverable` reason instead, so callers fail
+%% fast.
+t_unrecoverable_http_retry_aborts({init, Config}) ->
+    ok = meck:new(acme_client_httpc, [passthrough]),
+    Config;
+t_unrecoverable_http_retry_aborts({'end', _Config}) ->
+    ok = meck:unload(acme_client_httpc),
+    ok;
+t_unrecoverable_http_retry_aborts(_Config) ->
+    %% Short-circuit the directory request: return {ok, Ref} synchronously
+    %% (matching httpc's async contract) and post a synthetic 403 response
+    %% to the calling gen_statem's mailbox so the response correlates back
+    %% to the same Ref via Data#{request_id => Ref}.
+    ok = meck:expect(
+        acme_client_httpc,
+        get,
+        fun(_URL, _Opts) ->
+            Caller = self(),
+            Ref = make_ref(),
+            Caller !
+                {http,
+                    {Ref, {
+                        {"HTTP/1.1", 403, "Forbidden"},
+                        [{"content-type", "application/problem+json"}],
+                        <<"{\"type\":\"urn:ietf:params:acme:error:unauthorized\"}">>
+                    }}},
+            {ok, Ref}
+        end
+    ),
+    %% A normally-formed request that would otherwise reach Pebble — our
+    %% mock intercepts at the very first httpc call (directory discovery).
+    Result = run(
+        #{
+            dir_url => "https://localhost:14000/dir",
+            domains => ["a.local.net"],
+            challenge_fn => fun challenge_fn/1,
+            poll_interval => 100
+        }
+    ),
+    %% Without the fix this would have been {error, timeout} (5s poll).
+    ?assertMatch(
+        {error, #{
+            cause := http_retry_unrecoverable, reason := {unknown_response, 403, "Forbidden"}
+        }},
+        Result
+    ),
+    ok.


### PR DESCRIPTION
## Summary

`handle_event/4` only matched `?HTTP_RETRY(\"badNonce\")`. Any other retry signal — most commonly `?HTTP_RETRY({unknown_response, Code, Slogan})` emitted by `handle_rsp_with_hdr/6` when the CA returns an unhandled 4xx/5xx — fell through to the catch-all `unknown_event_ignored` clause:

```erlang
handle_event(StateName, EventType, EventContent, _Data) ->
    ?LOG(error, "unknown_event_ignored", ...),
    keep_state_and_data.
```

The state machine then stalled until `do_run/2`'s timeout fired, and callers saw `{error, timeout}` after the full timeout window with no clue what had gone wrong on the wire. Surfaced in production while running the EMQX ACME plugin against Let's Encrypt staging — saw `unknown_event_ignored, state_name: s10_finalize, event_content: {http_retry, {unknown_response, 403, \"Forbidden\"}}` followed minutes later by `acme_issuance_failed, reason: timeout`.

## Fix

Add a clause that catches any other `?HTTP_RETRY(Reason)`, replies to the caller with `{error, #{cause => http_retry_unrecoverable, reason => Reason}}`, and stops the state machine cleanly. No bounded retry/backoff is implemented yet — that's a separate enhancement; for now \"fail fast with the wire reason\" beats \"silently stall.\"

## Test plan

- [x] New CT case `t_unrecoverable_http_retry_aborts` mocks `acme_client_httpc:get/2` to synthesize a 403 directly to the gen_statem's mailbox, asserts the structured abort reason. Run: `rebar3 as test ct --suite test/acme_client_issuance_SUITE --case t_unrecoverable_http_retry_aborts` — passes.
- [x] `rebar3 compile` + `rebar3 dialyzer` clean
- [ ] Existing CT suite still green against Pebble (CI)

`meck` added under the test profile only — production deps unchanged.