### PR TITLE
fix: bump default HTTP timeout to 30s, document the override

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,19 @@
+# 2.0.4
+
+- Bump the default HTTP `timeout` and `connect_timeout` for ACME
+  requests from 10s to 30s. In practice the `finalize` step (CSR
+  submission → CA mints and signs the certificate) can exceed the old
+  10s budget on busy ACME servers — reproducibly observed against
+  Let's Encrypt staging — even though `directory` was returning in
+  well under a second on the same node. Callers saw a misleading
+  `{http_retry, timeout}` from `s10_finalize` for what was a transient
+  CA-side slowness. 30s gives more headroom without giving up
+  fail-fast on genuinely stuck requests; callers can raise (or lower)
+  the per-request budget by passing `httpc_opts => #{timeout => Ms,
+  connect_timeout => Ms}` in the issuance request — `http_opts/1`
+  merges the override on top of the new defaults. CT case
+  `t_httpc_opts_override_timeout` documents the override path.
+
 # 2.0.3
 
 - Fix `bad_return_from_state_function, ok` crash on the s11_certificate

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,17 @@
   connect_timeout => Ms}` in the issuance request — `http_opts/1`
   merges the override on top of the new defaults. CT case
   `t_httpc_opts_override_timeout` documents the override path.
+- Surface RFC 7807 problem details in the abort reason for
+  unrecoverable 4xx/5xx responses. `handle_rsp_with_hdr/6`'s
+  catch-all clause used to emit `{unknown_response, Code, Slogan}` no
+  matter what — so a 403 from a rate-limited CA reached callers as
+  bare `"Forbidden"` even when the body contained
+  `urn:ietf:params:acme:error:rateLimited` and a human `detail`.
+  The reason is now a map: `#{cause => unknown_response, http_code =>
+  Code, http_slogan => Slogan, problem => ParsedJSON}` (the `problem`
+  key is omitted when the body isn't `application/problem+json` /
+  `application/json`). The existing `t_unrecoverable_http_retry_aborts`
+  case asserts the new shape including the parsed error type.
 
 # 2.0.3
 

--- a/src/acme_client_httpc.erl
+++ b/src/acme_client_httpc.erl
@@ -40,9 +40,20 @@ HTTP client for ACME client to contact ACME servers.
 %% "All requests MUST include a User-Agent header".
 -define(USER_AGENT_HEADER, {"user-agent", "acme-erlang-client"}).
 
+%% Per-request HTTP timeouts. The defaults are the budget for any single
+%% ACME endpoint round-trip. 10s used to be the default but in practice
+%% the `finalize` step (CSR submission → CA mints + signs the cert) can
+%% exceed it on busy ACME servers — most reproducibly seen against Let's
+%% Encrypt staging — leaving callers staring at a misleading
+%% `{http_retry, timeout}` even when `directory` was reachable in well
+%% under a second. 30s gives more headroom without giving up fail-fast
+%% behaviour on genuinely stuck requests. Callers can override per
+%% request by passing a `httpc_opts` map (with `timeout` and/or
+%% `connect_timeout` keys) in the issuance request — `http_opts/1`
+%% merges the override on top of these defaults.
 -define(DEFAULT_OPTS, #{
-    timeout => timer:seconds(10),
-    connect_timeout => timer:seconds(10),
+    timeout => timer:seconds(30),
+    connect_timeout => timer:seconds(30),
     autoredirect => true,
     ssl => [{verify, verify_none}]
 }).

--- a/src/acme_client_issuance.erl
+++ b/src/acme_client_issuance.erl
@@ -934,8 +934,33 @@ handle_rsp_with_hdr(Code, Slogan, Hdrs, Body, Data, Type) when Code =< 400 ->
         false ->
             ?NEXT_ABORT(Data, #{cause => unknown_content_type, type => Type})
     end;
-handle_rsp_with_hdr(Code, Slogan, _Hdrs, _Body, Data, _Type) ->
-    ?NEXT_HTTP_RETRY(Data, {unknown_response, Code, Slogan}).
+handle_rsp_with_hdr(Code, Slogan, _Hdrs, Body, Data, Type) ->
+    %% Code > 400 with no recovery path. Try to surface the CA's RFC 7807
+    %% problem JSON so callers see a meaningful reason (e.g.
+    %% `urn:ietf:params:acme:error:rateLimited`) instead of just
+    %% `"Forbidden"` / `"Bad Request"`.
+    Base = #{cause => unknown_response, http_code => Code, http_slogan => Slogan},
+    Reason =
+        case decode_problem_body(Body, Type) of
+            {ok, Problem} -> Base#{problem => Problem};
+            error -> Base
+        end,
+    ?NEXT_HTTP_RETRY(Data, Reason).
+
+decode_problem_body(Body, "application/problem+json" ++ _) ->
+    try_decode_json(Body);
+decode_problem_body(Body, "application/json" ++ _) ->
+    try_decode_json(Body);
+decode_problem_body(_Body, _Type) ->
+    error.
+
+try_decode_json(Body) ->
+    try json:decode(Body) of
+        #{} = JSON -> {ok, JSON};
+        _ -> error
+    catch
+        _:_ -> error
+    end.
 
 handle_rsp_body(Code, Slogan, Hdrs, Body, Data, Type) ->
     try json:decode(Body) of

--- a/src/acme_client_issuance.erl
+++ b/src/acme_client_issuance.erl
@@ -192,7 +192,11 @@ The request is a map with the following keys:
 - `challenge_type`: The type of challenge to use, either `http-01` or `dns-01`.
 - `challenge_fn`: A function that returns the challenge for a given domain.
   The function is called with a list of challenges, and returns `ok`.
-- `httpc_opts`: The `httpc` client options.
+- `httpc_opts`: Per-request `httpc` options merged on top of the defaults
+  in `acme_client_httpc`. Common overrides are `timeout` and
+  `connect_timeout` (defaults: 30s each); `ssl` to supply CA certs;
+  `ipfamily` to force `inet`/`inet6`. Useful when the CA's `finalize`
+  endpoint is slow under load.
 - `poll_interval`: The interval to poll the order status.
 - `acc_key`: The `file://{path}` to the account key file, or term of type `public_key:private_key()`.
 - `acc_key_pass`: The password for the account key file, or `undefined` if the key is not encrypted.

--- a/test/acme_client_issuance_SUITE.erl
+++ b/test/acme_client_issuance_SUITE.erl
@@ -521,9 +521,20 @@ t_unrecoverable_http_retry_aborts(_Config) ->
         }
     ),
     %% Without the fix this would have been {error, timeout} (5s poll).
+    %% The reason is now a structured map carrying the parsed RFC 7807
+    %% problem body so callers see e.g. the ACME error type, not just
+    %% "Forbidden".
     ?assertMatch(
         {error, #{
-            cause := http_retry_unrecoverable, reason := {unknown_response, 403, "Forbidden"}
+            cause := http_retry_unrecoverable,
+            reason := #{
+                cause := unknown_response,
+                http_code := 403,
+                http_slogan := "Forbidden",
+                problem := #{
+                    <<"type">> := <<"urn:ietf:params:acme:error:unauthorized">>
+                }
+            }
         }},
         Result
     ),

--- a/test/acme_client_issuance_SUITE.erl
+++ b/test/acme_client_issuance_SUITE.erl
@@ -528,3 +528,23 @@ t_unrecoverable_http_retry_aborts(_Config) ->
         Result
     ),
     ok.
+
+%% Callers can raise (or lower) the per-request HTTP timeout by passing
+%% a `httpc_opts` override; the default is 30s, but a slow `finalize`
+%% endpoint under load may want more.
+t_httpc_opts_override_timeout({init, Config}) ->
+    Config;
+t_httpc_opts_override_timeout({'end', _Config}) ->
+    ok;
+t_httpc_opts_override_timeout(_Config) ->
+    R = run(
+        #{
+            dir_url => "https://localhost:14000/dir",
+            domains => ["a.local.net"],
+            challenge_fn => fun challenge_fn/1,
+            poll_interval => 100,
+            httpc_opts => #{timeout => 60_000, connect_timeout => 60_000}
+        }
+    ),
+    ?assertMatch({ok, _}, R),
+    ok.


### PR DESCRIPTION
## Summary

`?DEFAULT_OPTS` in `acme_client_httpc` had `timeout` and `connect_timeout` hardcoded to 10s. That's plenty for `directory` / `new-nonce` / `new-acct` (sub-second on Pebble and Let's Encrypt staging) but in practice the `finalize` step (CSR submission → CA mints and signs the certificate) can exceed it on busy ACME servers — reproducibly observed against Let's Encrypt staging while testing the EMQX ACME plugin: `directory` returning in ~0.5s on the same node, while `finalize` repeatedly tripped the 10s budget and surfaced as `{http_retry, timeout}` from `s10_finalize`.

(I don't have a calibrated bench of how slow staging's `finalize` actually gets — only the qualitative observation that 10s wasn't enough and 30s has been enough so far.)

## Fix

- Bump `?DEFAULT_OPTS.timeout` and `connect_timeout` to 30s.
- The per-request override path already existed via the issuance request's `httpc_opts` map (`http_opts/1` merges over the defaults). Documented it in the `request()` typespec so callers know they can dial it further up or down.

## Test plan

- [x] `rebar3 compile` clean.
- [x] New CT case `t_httpc_opts_override_timeout` exercises the override path against Pebble — passes.
- [ ] Existing CT suite still green against Pebble (CI).