### PR TITLE
fix: trigger cert download on s10_finalize -> s11_certificate

### DIFF
--- a/src/acme_client_issuance.erl
+++ b/src/acme_client_issuance.erl
@@ -693,7 +693,13 @@ s10_finalize(internal, ?HTTP_OK(_Code, _Slogan, Hdrs, JSON), Data0) ->
                 #{<<"status">> := <<"processing">>} ->
                     {next_state, s9_poll_order, Data};
                 #{<<"status">> := <<"valid">>, <<"certificate">> := CertURL} ->
-                    {next_state, s11_certificate, Data#{cert_url => CertURL}};
+                    %% s9_poll_order's "valid" branch supplies a
+                    %% {download_certificate, _} internal action so s11
+                    %% actually fetches the chain; without it s11 enters,
+                    %% logs "certificate_retrieval_start", and idles until
+                    %% the caller's timeout fires.
+                    Action = ?INTERNAL({download_certificate, str(CertURL)}),
+                    {next_state, s11_certificate, Data#{cert_url => CertURL}, [Action]};
                 _ ->
                     ?NEXT_ABORT(Data, #{cause => bad_finalize_response, response => JSON})
             end


### PR DESCRIPTION
## Summary

When `finalize` returns an order in `status="valid"` (CA issued synchronously inside the POST), `s10_finalize` transitions to `s11_certificate` without supplying the `{download_certificate, _}` internal action. `s11_certificate`'s enter clause only logs; without the explicit action it sits idle until the caller's `run/2` timeout fires, then returns `{error, timeout}`.

The bug never surfaced against Pebble because Pebble always replies to finalize with `status="processing"`, sending us through `s9_poll_order` (which **does** supply the action). Let's Encrypt production sometimes returns `status="valid"` directly when challenges have already been validated, hitting the broken branch.

## Impact

Every successful issuance against an already-authorized account on LE prod times out — but LE has still minted (and counted) the cert. Each failed run burns one of the 5 weekly duplicate-certificate slots per identifier without giving the caller anything to store. Hit this myself during a smoke test against LE production: 5 issuances all completed on LE's side, all timed out in the client, and we got rate-limited.

## Fix

Match the action structure already used by `s9_poll_order` → `s11_certificate` and by `s4_order` → `s11_certificate` (both of which work). One-line behavioral change plus a comment so the next reader doesn't re-introduce this.

## Test plan

- [ ] Verify the s10 → s11 path against a fast LE staging account (issue twice in quick succession; without this fix the second hangs).
- [ ] Confirm the s9_poll_order → s11 path (slow finalize) still works.